### PR TITLE
Support for CSS class and id selectors

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -220,6 +220,12 @@ This way, we can update items that share those variables without having to chang
 # Documentation
 
 ## Classes
+### ClassList
+The `ClassList` class is a custom collection which contains CSS class names and objects to which those classes are assigned. String-indexing into this class returns a `set[`[`Element`](#element)`]`.
+
+#### `ClassList` Attributes
+* **`classes`** &mdash; `dict[str, set[Element]]` containing class names and a `set` of the Elements to which each class is assigned.
+
 ### Element
 *Implements [`@tks_element`](#tks_element)*
 
@@ -231,9 +237,11 @@ The `Element` class is a wrapper around a tkinter widget, and should be created 
 * **`style`** &mdash; This `Element`'s style as a `dict[str, str]` or `None` if it does not exist.
 * **`widget`** &mdash; The tkinter `Widget` that this `Element` wraps.
 
-##### **Not Implemented**
+##### **Not Fully Implemented**
 * **`cl`** &mdash; Describes the element's CSS `class`, which can be used in a stylesheet to target that element and others with the same class.
     * **Important:** `class` is a restricted keyword in Python which cannot and should not be used outside the context of creating a Python class. `cl` is the only accepted word for this property.
+    * As of writing, only **one** class can be assigned to an element.
+    * As of writing, elements with both `cl` and `id` will only be styled according to their `id` attribute.
 * **`id`** &mdash; Describes the element's `id`, which can be used in a stylesheet to target that specific element.
 
 #### `Element` Methods
@@ -269,7 +277,9 @@ Optional title `str` and `Stylesheet` arguments can be passed directly to the `W
 If a stylesheet has not been passed to the `__init__` method, `self.style` will be equal to `None`.
 
 #### Window Attributes
+* **`cls`** &mdash; `ClassList` containing every CSS class used by this object's child elements (automatically populated).
 * **`elements`** &mdash; List of `Elements` contained within this object.
+* **`ids`** &mdash; `dict[str, Element]` mapping CSS ids to their respective `Element` within this object's child elements.
 * **`stylesheet`** &mdash; The `stylesheet` passed to this object during instantiation.
 * **`style`** &mdash; This `Element`'s style as a `dict[str, str]` or `None` if it does not exist.
 

--- a/tks/class_list.py
+++ b/tks/class_list.py
@@ -1,0 +1,26 @@
+from tks.element import Element
+
+
+class ClassList:
+    """
+    Container for CSS class names and sets of elements
+    to which those class names are assigned. This object
+    can be indexed into using CSS class names.
+
+    ### Example
+    ```python
+    class_list["blue"] -> {element1, element2, ...}
+    ```
+    """
+
+    def __init__(self):
+        self.classes: dict[str, set[Element]] = dict()
+
+    def __getitem__(self, attr: str) -> set[Element]:
+        if self.classes.get(attr) is None:
+            self.classes[attr] = set()
+
+        return self.classes[attr]
+
+    def __repr__(self):
+        return f"""ClassList ({self.classes})"""

--- a/tks/core.py
+++ b/tks/core.py
@@ -11,7 +11,9 @@ def tks_element(base: object):
     Decorates a tks class in order to add the following instance methods:
     * `self.add(widget, **kwargs)`
     * `self.get_style_of(name, fallback)`
-    * `self.root()`
+
+    And the following properties:
+    * `self.root`
 
     The `add` method creates a new tks `Element` which contains the
     provided `tk.Widget` as a direct child element. Keyword arguments
@@ -23,7 +25,7 @@ def tks_element(base: object):
     a `dict[str, str]` will be returned. Otherwise, this method returns
     `None`.
 
-    The `root` method returns the `Window` which contains everything.
+    The `root` property returns the root `Window`.
     """
 
     class TksElement(base):
@@ -45,7 +47,7 @@ def tks_element(base: object):
             element = Element(widget, self, **kwargs)
             self.elements.append(element)
 
-            # element.widget.pack()
+            element.widget.pack()
 
             return element
 
@@ -64,9 +66,10 @@ def tks_element(base: object):
 
             return self.stylesheet.get(name)
 
+        @property
         def root(self):
             if self.__dict__.get("parent"):
-                return self.parent.root()
+                return self.parent.root
             return self
 
         def __getattr__(self, attr: str) -> Optional[Any]:
@@ -89,12 +92,12 @@ def parse_css_kwargs(obj, **kwargs) -> dict[str, str]:
                 target = obj.parent
 
             else:
-                target = obj.root()
+                target = obj.root
 
             total = float(target[k] / 100) * percent
             kwargs[k] = str(int(total))
 
-    return obj.root().stylesheet.format_properties(kwargs)
+    return obj.root.stylesheet.format_properties(kwargs)
 
 
 def update_style(fn):
@@ -119,7 +122,7 @@ def update_style(fn):
         if self.style is None:
             self.style = dict()
 
-        if self.root().stylesheet is None:
+        if self.root.stylesheet is None:
             return
 
         kwargs = parse_css_kwargs(self, **kwargs)

--- a/tks/element.py
+++ b/tks/element.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 from tks.core import update_style, tks_element
-from tks.dbg import dbg
 from typing import Optional
 import tkinter as tk
 
@@ -13,6 +12,9 @@ class Element:
 
         self.elements: Optional[list[Element]] = None
         self.parent = parent
+
+        if self.id is not None:
+            self.root.ids[self.id] = self
 
         if isinstance(parent, Element):
             self.widget = widget(self.parent.widget, **kwargs)
@@ -34,7 +36,6 @@ class Element:
         if kwargs:
             self.configure(**kwargs)
 
-    @dbg
     def bind(self, *args):
         """Bind an event and handler to an `Element`'s widget."""
         self.widget.bind(*args)
@@ -43,7 +44,6 @@ class Element:
     def configure(self, **kwargs):
         """Configure properties of an `Element` and its widget."""
         for p in ("cl", "id"):
-            if kwargs.get(p, None) is not None:
-                self.__dict__[p] = kwargs.pop(p)
+            self.__dict__[p] = kwargs.pop(p, None)
 
         self.widget.configure(**kwargs)

--- a/tks/error.py
+++ b/tks/error.py
@@ -1,0 +1,2 @@
+class DuplicateIdError(Exception):
+    pass

--- a/tks/window.py
+++ b/tks/window.py
@@ -1,3 +1,4 @@
+from tks.class_list import ClassList
 from tks.core import update_style, tks_element
 from tks.element import Element
 from tks.stylesheet import Stylesheet
@@ -37,7 +38,7 @@ class Window(tk.Tk):
     @property
     def cls(self) -> Optional[dict[str, list[Element]]]:
         if self.__cls is None:
-            self.__cls = dict()
+            self.__cls = ClassList()
         return self.__cls
 
     @update_style

--- a/tks/window.py
+++ b/tks/window.py
@@ -1,4 +1,5 @@
 from tks.core import update_style, tks_element
+from tks.element import Element
 from tks.stylesheet import Stylesheet
 from typing import Optional
 import re
@@ -15,7 +16,10 @@ class Window(tk.Tk):
         # Prevent child elements from resizing the main window.
         self.pack_propagate(0)
 
+        self.__cls = None
+        self.__ids = None
         self.elements = None
+
         self.stylesheet = stylesheet
         self.width, self.height, self.x, self.y = re.split("[x+]", self.geometry())
         self.style = None
@@ -23,6 +27,18 @@ class Window(tk.Tk):
         if stylesheet is not None:
             if stylesheet.get("Window"):
                 self.configure(**self.stylesheet.get("Window"))
+
+    @property
+    def ids(self) -> Optional[dict[str, Element]]:
+        if self.__ids is None:
+            self.__ids = dict()
+        return self.__ids
+
+    @property
+    def cls(self) -> Optional[dict[str, list[Element]]]:
+        if self.__cls is None:
+            self.__cls = dict()
+        return self.__cls
 
     @update_style
     def configure(self, **kwargs):


### PR DESCRIPTION
## Changes in this Pull Request
<!-- Describe your changes in detail. -->
This PR adds basic support for CSS class and id selectors (`.class`, `#id`) using the keyword arguments `cl` for class and `id` for id.

The current implementation only allows for one CSS class per element. In addition, if both `cl` and `id` are defined, `id` will always be preferred and the **entire** style will be overwritten.

## Context
<!-- What is the motivation behind this change? Why should it be implemented? -->
```python
# main.py
stylesheet = tks.Stylesheet("./main.css")
root = tks.Window("My Application", stylesheet)

root.add(tk.Label, text="Only I can be blue!", id="blue")

# Only one element may exist per id. Uncommenting the following line raises an error.
# root.add(tk.Label, text="I raise an error!", id="blue")

root.add(tk.Label, text="I can be green!", cl="green")
root.add(tk.Label, text="I can be green too!", cl="green")

root.add(tk.Label, text="I'm normal text!")

```

```css
/* main.css */
Window {
    width: 400;
    height: 200;
}

#blue {
    color: #0ac;
}

.green {
    color: #0c8;
}
```

## Pre-Submission Checklist
- [*] I have reviewed my code and tested it for bugs.
- [*] I have included comments and docstrings explaining my code.
- [*] I have updated the documentation to include information relevant to my changes.
- [*] My code is compliant to the [style guidelines](./CONTRIBUTING.md#bare-bones-style-guidelines).
