### PR TITLE
CSS Inheritance

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ currently being supported with security updates.-->
 
 ## Reporting a Vulnerability
 
-To report a vulnerability, please contact the maintainer via one of the links in their profile.
+To report a vulnerability, please contact the maintainer via [email](mailto:_@piccoloser.com).
 
 Once reported, vulnerabilities will be given top priority.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -227,26 +227,19 @@ The `Element` class is a wrapper around a tkinter widget, and should be created 
 
 #### `Element` Attributes
 
-##### **`cl`** *Not Fully Implemented*
-Describes the element's CSS `class`, which can be used in a stylesheet to target that element and others with the same class.
+##### **`cl`**
+Describes the element's CSS `class`, which can be used in a stylesheet to target that element and others with the same class. Multiple classes can be applied to one object by separating them with a single space, with properties from latter classes overwriting that of the former.
 * **Important:** `class` is a restricted keyword in Python which cannot and should not be used outside the context of creating a Python class. `cl` is the only accepted word for this property.
-* As of writing, only **one** class can be assigned to an element.
-* As of writing, elements with both `cl` and `id` will only be styled according to their `id` attribute.
+* As of writing, properties defined in `id` will be overwritten by those defined in `cl`. If a value defined in `id` is not touched by a CSS class, it will be left as is.
 
 ##### **`elements`**
 List of `Elements` contained within this object.
 
-##### **`id`** *Not Fully Implemented*
-Describes the element's `id`, which can be used in a stylesheet to target that specific element.
+##### **`id`**
+Describes the element's `id`, which can be used in a stylesheet to target that specific element. Only one element can be created with each `id`.
 
 ##### **`parent`**
 The `Element` or `Window` which contains this object.
-
-##### **`style`**
-This `Element`'s style as a `dict[str, str]` or `None` if it does not exist.
-
-##### **`widget`**
-The tkinter `Widget` that this `Element` wraps.
 
 #### `Element` Methods
 
@@ -306,10 +299,20 @@ Creates a new `Element` containing the specified widget with `self` as the `Elem
 ##### **`get_style_of(name: str, fallback: str | None = None) -> dict[str, str]`**
 Returns the style of a widget which has been defined in a stylesheet, given the widget name (eg. `tk.Frame.__name__ -> "Frame"`), or optionally the style of another `fallback` widget.
 
+##### **`parents()`**
+Returns an ascending generator over the ancesters of a `TksElement` ending with the root (inclusive).
+
+
 #### Introduced Properties
 
 ##### **`root`**
 Returns the root `Window`.
+
+##### **`style`**
+Returns the style dictionary (`dict[str, str]`) associated with the object, creating and returning a new `dict` if it doesn't already exist.
+
+##### **`widget`**
+Returns the tkinter `Widget` associated with the object or `None` if it doesn't exist.
 
 ### Window
 *Inherits from [`TksElement`](#tkselement)*
@@ -330,13 +333,10 @@ If a stylesheet has not been passed to the `__init__` method, `self.style` will 
 List of `Elements` contained within this object.
 
 ##### **`ids`**
-`dict[str, Element]` mapping CSS ids to their respective `Element` within this object's child elements.
+`dict[str, Element]` mapping CSS ids to their respective `Element` within this object's child elements (automatically populated).
 
 ##### **`stylesheet`**
 The `stylesheet` passed to this object during instantiation.
-
-##### **`style`**
-This `Element`'s style as a `dict[str, str]` or `None` if it does not exist.
 
 ## Decorators
 ### `@update_style`

--- a/tks/constants.py
+++ b/tks/constants.py
@@ -1,3 +1,19 @@
+# Property name translations.
+CSS_PROPERTY_NAME_TRANSLATIONS = {
+    "background": "bg",
+    "background-color": "bg",
+    "border-style": "relief",
+    "border-width": "bd",
+    "color": "fg",
+}
+
+# Supported properties which inherit from
+# the parent element by default.
+INHERITED_PROPERTIES: list[str] = [
+    "background",
+    "color",
+]
+
 # Regular expressions to help parse CSS.
 MATCH_COMMENT = r"/\*.+?\*/"
 MATCH_BLOCK = r"\{.*?\}"
@@ -38,13 +54,4 @@ STYLE_CONFIG_OPTIONS: set[str] = {
     "padx",
     "pady",
     "width",
-}
-
-# Property name translations.
-CSS_PROPERTY_NAME_TRANSLATIONS = {
-    "background": "bg",
-    "background-color": "bg",
-    "border-style": "relief",
-    "border-width": "bd",
-    "color": "fg",
 }

--- a/tks/element.py
+++ b/tks/element.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from typing import Generator
 from tks.core import TksElement, update_style
 from tks.error import DuplicateIdError
 import tkinter as tk
@@ -55,12 +56,13 @@ class Element(TksElement):
         else:
             fallback: str | None = None
             if widget.__name__ == "Frame":
-                fallback = "Window"
+                self.widget.pack_propagate(0)
 
             # Style the element from its selector or the fallback.
             self.style = self.get_style_of(widget.__name__, fallback)
 
         # Configure with values from CSS stylesheet.
+        self.inherit_style()
         self.configure(self.style)
 
         # Reconfigure the widget with any provided keyword arguments.
@@ -77,4 +79,16 @@ class Element(TksElement):
         for p in ("cl", "id"):
             self.__dict__[p] = kwargs.pop(p, None)
 
+        if "frame" in self.widget_name:
+            kwargs.pop("fg", None)
+
         self.widget.configure(**kwargs)
+
+    def parents(self) -> Generator[Element]:
+        parent = self.parent
+
+        if parent.parent is not None:
+            yield parent.parent
+
+        else:
+            yield parent

--- a/tks/stylesheet.py
+++ b/tks/stylesheet.py
@@ -30,7 +30,7 @@ class Stylesheet:
         # Minify and store the provided CSS.
         self.source_min = self.minify_css(source_path)
 
-        # Parse and store the minified CSS into `self.styles`.
+        # Parse and store the minified CSS into self.styles.
         for selector, block in zip(self.get_selectors(), self.get_blocks()):
             self.styles[selector] = self.parse_block(block)
 

--- a/tks/window.py
+++ b/tks/window.py
@@ -56,4 +56,5 @@ class Window(TksElement, tk.Tk):
 
     @update_style
     def configure(self, **kwargs):
+        kwargs.pop("fg", None)
         super().configure(**kwargs)

--- a/tks/window.py
+++ b/tks/window.py
@@ -27,12 +27,10 @@ class Window(TksElement, tk.Tk):
         # the id and the value is the one Element with that id.
         self.__ids: dict[str, Element] = None
 
-        # List of child Elements of this Window.
+        # List of direct children of this window.
         self.elements: list[Element] = None
 
-        # Dictionary describing the appearance of this Window.
-        self.style: dict[str, str] = None
-
+        # Style dictionary associated with this window.
         self.stylesheet: Stylesheet | None = stylesheet
 
         # tk.Tk().geometry returns a str = "{width}x{height}+{x}+{y}".


### PR DESCRIPTION
## Changes in this Pull Request
<!-- Describe your changes in detail. -->
* Support for multiple CSS classes via the `cl` keyword.
    * Classes are supplied as a string and multiple classes must be separated by a single space.
    * Classes respect the order in which they are declared and latter class properties will overwrite those of former classes.
```python
# Example 1 (This text will be red.)
root.add(tk.Label, cl="red-text")

# Example 2 (This text will be blue because of class declaration order.)
root.add(tk.Label, cl="red-text blue-text")

# Example 3 (This text will still be red, but it will also have a white background.)
root.add(tk.Label, cl="red-text white-bg")
```
* Implements support for CSS property inheritance from parent elements.
    * `background` and `color` inherit from their parent or a higher ancestor automatically.
    * Explicitly defined values will still overwrite those defined in a stylesheet.
```python
# Example
frame = root.add(tk.Frame, cl="red-text")
frame.add(tk.Label, text="I am red!")

frame2 = frame.add(tk.Frame)
frame2.add(tk.Label, text="I am also red!")

frame2.add(tk.Label, fg="green", text="I am green instead!")
```
* Simplifies the implementation of various attributes.
    * `self.widget` no longer requires checks against `self.__dict__.get("widget")` and returns `None` if it doesn't exist.
    * `self.style` no longer needs to be instantiated if it was previously `None`. It will always return the expected style or an empty `dict`.
    * `self.root` has been refactored to read more like a standard recursive function.
* `TksElement.get_style_of()` now always returns `None` or a style.
    * There were cases where it would return nothing or a new `dict`.

### Differences between `TksElement.__getattr__()` and `TksElement.__getitem__()`
There is now a specific difference between accessing a value via `.` and `[]`.
* `my_element.test` raises an `AttributeError`.
    * `.` checks first the element itself, then its widget.
* `my_element["test"]` returns `None`.
    * `[]` checks *only* the element itself.

## Relevant Issue (If Applicable)
<!-- If your PR is meant to resolve an issue or addresses an issue indirectly, mention that issue here. -->


## Context
<!-- What is the motivation behind this change? Why should it be implemented? -->


## Pre-Submission Checklist
- [*] I have reviewed my code and tested it for bugs.
- [*] I have included comments and docstrings explaining my code.
- [*] I have updated the documentation to include information relevant to my changes.
- [*] My code is compliant to the [style guidelines](./CONTRIBUTING.md#bare-bones-style-guidelines).
