### PR TITLE
Add support for `color` keyword in Frame elements

### DIFF
--- a/tks/constants.py
+++ b/tks/constants.py
@@ -14,6 +14,11 @@ INHERITED_PROPERTIES: list[str] = [
     "color",
 ]
 
+# Properties not supported by container objects.
+INVALID_CONTAINER_PROPERTIES: list[str] = [
+    "color",
+]
+
 # Regular expressions to help parse CSS.
 MATCH_COMMENT = r"/\*.+?\*/"
 MATCH_BLOCK = r"\{.*?\}"

--- a/tks/core.py
+++ b/tks/core.py
@@ -9,7 +9,7 @@ from tks.constants import (
 import re
 
 
-translate_css = lambda x: CSS_PROPERTY_NAME_TRANSLATIONS[x]
+translate_css = lambda x: CSS_PROPERTY_NAME_TRANSLATIONS.get(x)
 
 
 class TksElement:
@@ -26,6 +26,15 @@ class TksElement:
         Parameters
         - widget: `tkinter.Widget` - Type of widget to be created.
         - `**kwargs` - Keyword arguments to use when creating the widget.
+
+        The following CSS values can be passed as keyword arguments:
+            * `color=...`
+            * `width` / `height` `= "...%"`
+
+        Under normal circumstances, tkinter's `Frame` widget does not
+        accept the `fg` keyword argument. This is handled instead by tks
+        such that a container may define the default font color of Label
+        widgets it contains.
         """
         from tks.element import Element
 

--- a/tks/element.py
+++ b/tks/element.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import Generator
-from tks.core import TksElement, update_style
+from tks.constants import INVALID_CONTAINER_PROPERTIES
+from tks.core import TksElement, translate_css, update_style
 from tks.error import DuplicateIdError
 import tkinter as tk
 
@@ -10,6 +11,13 @@ class Element(TksElement):
         # CSS id and class values. None if not provided.
         self.id = kwargs.pop("id", None)
         self.cl = kwargs.pop("cl", None)
+        other_kwargs = dict()
+
+        if widget is tk.Frame:
+            for k in INVALID_CONTAINER_PROPERTIES:
+                value = kwargs.pop(k, None)
+                if value is not None:
+                    other_kwargs[translate_css(k)] = value
 
         # List of direct children of this Element.
         self.elements: list[Element] | None = None
@@ -36,6 +44,7 @@ class Element(TksElement):
 
         # Style the element from its selector or the fallback.
         self.style = self.get_style_of(widget.__name__, fallback) or dict()
+        self.style.update(other_kwargs)
 
         if self.id is not None:
             # Raise an error if an element with this id already exists.


### PR DESCRIPTION
## Changes in this Pull Request
<!-- Describe your changes in detail. -->
* Adds support for the `color` keyword argument when creating a `tk.Frame`-based `Element`.

## Context
<!-- What is the motivation behind this change? Why should it be implemented? -->
As it stands currently, a `color` value can be defined in the CSS stylesheet for `Frame` objects, and that color will be applied to all subsequent `Label` elements in the hierarchy. However, `Frame` elements created with the `add()` method, also provided a `color` attribute, will cause an error. This is because tkinter's `Frame` widget does not accept a `fg` argument (which "color" is translated to automatically).

With the changes in this PR, tks will no longer pass the `color` attribute to the `Frame` widget. Instead, that attribute will be stored in `Element.style` which is referenced by the object's child elements.

## Pre-Submission Checklist
- [*] I have reviewed my code and tested it for bugs.
- [*] I have included comments and docstrings explaining my code.
- [*] I have updated the documentation to include information relevant to my changes.
- [*] My code is compliant to the [style guidelines](./CONTRIBUTING.md#bare-bones-style-guidelines).
