### PR TITLE
Support for Python >3.8

### DIFF
--- a/example/main.css
+++ b/example/main.css
@@ -17,7 +17,7 @@
 */
 
 :root {
-    --bg: white;
+    --bg: #333;
     --fg: #ddd;
     --red: #a22;
     --green: #082;

--- a/example/main.css
+++ b/example/main.css
@@ -17,7 +17,7 @@
 */
 
 :root {
-    --bg: #333;
+    --bg: white;
     --fg: #ddd;
     --red: #a22;
     --green: #082;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "tkx"
-version = "0.1.1"
+version = "0.1.2"
 description = ""
 authors = ["Hunter Logan <_@piccoloser.com>"]
 readme = "README.md"
 packages = [{include = "tkx", from = "src"}]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.8"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/tkx/core.py
+++ b/src/tkx/core.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from tkinter import Widget
-from typing import Any, Callable, Literal
+from typing import Any, Callable, Literal, Union
 from tkx.constants import (
     CSS_PROPERTY_NAME_TRANSLATIONS,
     INHERITED_PROPERTIES,
@@ -17,9 +17,9 @@ class TkxElement:
     def __init__(self):
         super().__init__()
         self.__display: Literal["block", "flex", "grid", "none"] = "block"
-        self.__parent: TkxElement | None = None
-        self.__style: dict[str, str] | None = None
-        self.__widget: Widget | None = None
+        self.__parent: Union[TkxElement, None] = None
+        self.__style: Union[dict[str, str], None] = None
+        self.__widget: Union[Widget, None] = None
 
     def add(self, widget: Widget, **kwargs):
         """
@@ -63,7 +63,7 @@ class TkxElement:
 
         raise NotImplementedError()
 
-    def get_style_of(self, name: str, fallback: str | None = None) -> dict[str, str] | None:
+    def get_style_of(self, name: str, fallback: Union[str, None] = None) -> Union[dict[str, str], None]:
         """
         Returns the style dictionary associated with the given name if it
         can be found in the root window's stylesheet. Accepts an optional
@@ -124,7 +124,7 @@ class TkxElement:
         return self.parent.root
 
     @property
-    def style(self) -> dict[str, str] | None:
+    def style(self) -> Union[dict[str, str], None]:
         """
         Returns the style dictionary associated with this object or
         creates a new `dict` and returns it.
@@ -135,11 +135,11 @@ class TkxElement:
         return self.__style
 
     @style.setter
-    def style(self, value: dict[str, str] | None) -> None:
+    def style(self, value: Union[dict[str, str], None]) -> None:
         self.__style = value
 
     @property
-    def widget(self) -> Widget | None:
+    def widget(self) -> Union[Widget, None]:
         """Returns the widget associated with this object or `None`."""
         return self.__widget
 
@@ -148,19 +148,19 @@ class TkxElement:
         self.__widget = value
 
     @property
-    def widget_name(self) -> str | None:
+    def widget_name(self) -> Union[str, None]:
         """Returns the lowercase name of this object's widget or `None`."""
         if self.widget is not None:
             return re.search(r"\w+", str(self.widget).split(".")[-1])[0]
         return None
 
-    def __getattr__(self, attr: str) -> Any | None:
+    def __getattr__(self, attr: str) -> Union[Any, None]:
         # If no attribute is found in self, check self.widget.
         if self[attr] is None and self.widget is not None:
             return getattr(self.widget, attr)
         return self[attr]
 
-    def __getitem__(self, attr: str) -> Any | None:
+    def __getitem__(self, attr: str) -> Union[Any, None]:
         return self.__dict__.get(attr)
 
     def __setitem__(self, key: str, value: Any) -> None:
@@ -198,36 +198,8 @@ def update_style(fn):
     Takes a style dictionary and/or keyword arguments, then parses
     the given values as CSS before configuring the widget wrapped by
     the caller. Dictionary values are overwritten by keyword arguments.
-
-    #### The following examples require `--red` to be defined in the stylesheet.
-    ### Example 1
-
-    ```python
-    my_element.configure(color="var(--red)")
-    ```
-
-    becomes `my_element.configure(fg="#f00")`
-
-    ### Example 2
-
-    ```python
-    my_style = {"color": "var(--red)"}
-    my_element.configure(my_style)
-    ```
-
-    becomes `my_element.configure(fg="#f00")`
-
-    ### Example 3
-
-    ```python
-    my_style = {"color": "var(--red)"}
-    my_element.configure(my_style, width=50)
-    ```
-
-    becomes `my_element.configure(fg="#f00", width=50)`
     """
-
-    def func(self, args: dict[str, Any] | None = None, **kwargs) -> Callable:
+    def func(self, args: Union[dict[str, Any], None] = None, **kwargs) -> Callable:
         # If both a positional dictionary and keyword arguments
         # are provided, update the dictionary with the provided
         # keyword arguments.

--- a/src/tkx/element.py
+++ b/src/tkx/element.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Generator
+from typing import Generator, Union
 from tkx.constants import INVALID_CONTAINER_PROPERTIES
 from tkx.core import TkxElement, translate_css, update_style
 from tkx.error import DuplicateIdError
@@ -24,7 +24,7 @@ class Element(TkxElement):
                     other_kwargs[translate_css(k)] = value
 
         # List of direct children of this Element.
-        self.elements: list[Element] | None = None
+        self.elements: Union[list[Element], None] = None
 
         # Object to which this Element is added.
         self.parent = parent
@@ -42,7 +42,7 @@ class Element(TkxElement):
         else:
             self.widget = widget(self.parent, **kwargs)
 
-        fallback: str | None = None
+        fallback: Union[str, None] = None
         if self.widget_name == "frame":
             self.widget.pack_propagate(0)
 
@@ -92,7 +92,7 @@ class Element(TkxElement):
 
         self.widget.configure(**kwargs)
 
-    def parents(self) -> Generator[Element]:
+    def parents(self) -> Generator[Element, None, None]:
         """Returns an ascending generator of an `Element`'s parents."""
         # Get a reference to the current container.
         ref = self.__iter_parent

--- a/src/tkx/stylesheet.py
+++ b/src/tkx/stylesheet.py
@@ -1,3 +1,4 @@
+from typing import Union
 from pathlib import Path
 from tkx.constants import (
     CSS_PROPERTY_NAME_TRANSLATIONS,
@@ -41,7 +42,7 @@ class Stylesheet:
         """
         return {k: self.var(str(v)) for k, v in properties.items()}
 
-    def get(self, name: str) -> str | None:
+    def get(self, name: str) -> Union[str, None]:
         """
         Return the CSS block associated with `name` or `None` if it does
         not exist.
@@ -56,7 +57,7 @@ class Stylesheet:
         # Remove any leftover curly braces and return the result.
         return (*map(lambda i: re.sub(MATCH_BRACES, "", i), result),)
 
-    def get_property(self, widget_name: str, property: str) -> str | None:
+    def get_property(self, widget_name: str, property: str) -> Union[str, None]:
         """Return the value of a property given a selector and property name."""
         if self.styles.get(widget_name) is None:
             print(f"get_property found no CSS style for {widget_name}.")
@@ -108,7 +109,7 @@ class Stylesheet:
             filter(lambda k: results.get(k) is None, translated_results.items())
         )
 
-    def var(self, value: str) -> str | None:
+    def var(self, value: str) -> Union[str, None]:
         """Return the value associated with a given variable name."""
         name = re.findall(MATCH_VAR_NAME, value)
 

--- a/src/tkx/window.py
+++ b/src/tkx/window.py
@@ -1,3 +1,4 @@
+from typing import Union
 from tkx.core import update_style, TkxElement
 from tkx.element import Element
 from tkx.stylesheet import Stylesheet
@@ -6,7 +7,7 @@ import tkinter as tk
 
 
 class Window(TkxElement, tk.Tk):
-    def __init__(self, title: str = "", stylesheet: Stylesheet | None = None):
+    def __init__(self, title: str = "", stylesheet: Union[Stylesheet, None] = None):
         super().__init__()
 
         # Update window geometry.
@@ -31,7 +32,7 @@ class Window(TkxElement, tk.Tk):
         self.elements: list[Element] = None
 
         # Style dictionary associated with this window.
-        self.stylesheet: Stylesheet | None = stylesheet
+        self.stylesheet: Union[Stylesheet, None] = stylesheet
 
         # tk.Tk().geometry returns a str = "{width}x{height}+{x}+{y}".
         # Split the string along "x" and "+", then assign those values.
@@ -41,13 +42,13 @@ class Window(TkxElement, tk.Tk):
             self.configure(self.stylesheet.get("Window"))
 
     @property
-    def ids(self) -> dict[str, Element] | None:
+    def ids(self) -> Union[dict[str, Element], None]:
         if self.__ids is None:
             self.__ids = dict()
         return self.__ids
 
     @property
-    def cls(self) -> dict[str, list[Element]] | None:
+    def cls(self) -> Union[dict[str, list[Element]], None]:
         if self.__cls is None:
             self.__cls = dict()
         return self.__cls


### PR DESCRIPTION
## Changes in this Pull Request
Added support for Python 3.8 and up, bumped minor version and got rid of the explanation in core.py (I'll add it back if requested).

## Relevant Issue (If Applicable)
Most people don't use the latest Python and end up using either 3.8.x or 3.9.x (like I do).


## Context
Most people don't use the latest Python version like 3.8.x/3.9.x and most libraries often support these Python versions because of how widely those are used.


## Pre-Submission Checklist
- [Y] I have reviewed my code and tested it for bugs.
- [Y] I have included comments and docstrings explaining my code.
- [Y] I have updated the documentation to include information relevant to my changes.
- [Y] My code is compliant to the [style guidelines](./CONTRIBUTING.md#bare-bones-style-guidelines).
